### PR TITLE
Added config for saving actions in db

### DIFF
--- a/config/commons.php
+++ b/config/commons.php
@@ -9,6 +9,9 @@ return [
     ],
 
     'configuration' => [
+        'actions' => [
+            'save_in_db' => env('ACTIONS_SAVE_IN_DB', true),
+        ],
         'domains' => [
             'allow_non_fqdn' => env('ALLOW_NON_FQDN', false),
         ]

--- a/src/Actions/AbstractAction.php
+++ b/src/Actions/AbstractAction.php
@@ -14,6 +14,7 @@ use NextDeveloper\Commons\Database\Models\ActionLogs;
 use NextDeveloper\Commons\Database\Models\Actions;
 use NextDeveloper\Commons\Exceptions\CannotValidateActionRequestException;
 use NextDeveloper\Commons\Exceptions\NotAllowedException;
+use NextDeveloper\Commons\Helpers\ActionsHelper;
 use NextDeveloper\IAM\Helpers\UserHelper;
 
 class AbstractAction implements ShouldQueue
@@ -49,8 +50,8 @@ class AbstractAction implements ShouldQueue
         $this->createAction();
 
         //  Sometimes parameters can be passed as an array, thats why we are setting the first element as the parameters
-        if($params) {
-            if(array_key_exists(0, $params))
+        if ($params) {
+            if (array_key_exists(0, $params))
                 $params = $params[0];
 
             $validator = Validator::make($params, $this::PARAMS);
@@ -62,10 +63,12 @@ class AbstractAction implements ShouldQueue
         }
 
         foreach ($this->allowedRoles as $role) {
-            if(!UserHelper::hasRole($role)) {
+            if (!UserHelper::hasRole($role)) {
                 throw new NotAllowedException('You dont have the right privilige and/or role to run this action.');
             }
         }
+
+        if (!ActionsHelper::saveInDb()) return;
 
         $this->userId = UserHelper::me()->id;
         $this->accountId = UserHelper::currentAccount()->id;
@@ -86,42 +89,47 @@ class AbstractAction implements ShouldQueue
      *
      * @return mixed
      */
-    public function getActionId() {
-        if(!$this->action) {
+    public function getActionId()
+    {
+        if (!$this->action) {
             $this->createAction();
         }
 
         return $this->action->uuid;
     }
 
-    private function createAction() {
+    private function createAction()
+    {
+        if (!ActionsHelper::saveInDb()) return;
+
         $class = get_class($this->model);
         $id = $this->model->id;
 
         $this->action = Actions::create([
-            'action'    =>  get_class($this),
-            'progress'  =>  0,
-            'runtime'   =>  0,
-            'object_id'     =>  $id,
-            'object_type'   =>  $class,
-            'iam_account_id'    => $this->getAccountId(),
-            'iam_user_id'       =>  $this->getUserId()
+            'action' => get_class($this),
+            'progress' => 0,
+            'runtime' => 0,
+            'object_id' => $id,
+            'object_type' => $class,
+            'iam_account_id' => $this->getAccountId(),
+            'iam_user_id' => $this->getUserId()
         ]);
 
         $this->action = $this->action->fresh();
     }
 
-    public function getUserId() {
-        if(UserHelper::me()) {
+    public function getUserId()
+    {
+        if (UserHelper::me()) {
             return UserHelper::me()->id;
         }
 
-        if(property_exists($this->model, 'iam_user_id')) {
+        if (property_exists($this->model, 'iam_user_id')) {
             return $this->model->iam_user_id;
         }
 
-        if($this->action) {
-            if($this->action->iam_user_id) {
+        if ($this->action) {
+            if ($this->action->iam_user_id) {
                 return $this->model->iam_user_id;
             }
         }
@@ -129,17 +137,18 @@ class AbstractAction implements ShouldQueue
         return null;
     }
 
-    public function getAccountId() {
-        if(UserHelper::me()) {
+    public function getAccountId()
+    {
+        if (UserHelper::me()) {
             return UserHelper::currentAccount()->id;
         }
 
-        if(property_exists($this->model, 'iam_account_id')) {
+        if (property_exists($this->model, 'iam_account_id')) {
             return $this->model->iam_account_id;
         }
 
-        if($this->action) {
-            if($this->action->iam_account_id) {
+        if ($this->action) {
+            if ($this->action->iam_account_id) {
                 return $this->model->iam_account_id;
             }
         }
@@ -147,19 +156,23 @@ class AbstractAction implements ShouldQueue
         return null;
     }
 
-    public function setFlow($flow) {
+    public function setFlow($flow)
+    {
         $this->flowId = $flow;
     }
 
-    public function getFlow() {
+    public function getFlow()
+    {
         return $this->flowId;
     }
 
-    public function setNode($node) {
+    public function setNode($node)
+    {
         $this->nodeId = $node;
     }
 
-    public function getNode() {
+    public function getNode()
+    {
         return $this->nodeId;
     }
 
@@ -169,18 +182,21 @@ class AbstractAction implements ShouldQueue
         UserHelper::setCurrentAccountById($this->action->iam_account_id);
     }
 
-    public function setProgress($percent, $completedAction) {
+    public function setProgress($percent, $completedAction)
+    {
+        if (!ActionsHelper::saveInDb()) return;
+
         //  We put this here to fix the action owner problem. But we need to create much more smart solution for this
         //  in the next version of this module.
         $this->setUserAsThisActionOwner();
 
-        if(!$this->startTime) {
+        if (!$this->startTime) {
             $this->startTime = now();
         }
 
         $diff = 0;
 
-        if(!$this->latestTime) {
+        if (!$this->latestTime) {
             $this->latestTime = now();
         } else {
             $now = Carbon::now();
@@ -189,73 +205,77 @@ class AbstractAction implements ShouldQueue
             $this->latestTime = now();
         }
 
-        if(!$this->action) {
+        if (!$this->action) {
             $this->createAction();
         }
 
         UserHelper::setUserById($this->getUserId());
 
-        if(config('leo.debug.action_logs')) {
+        if (config('leo.debug.action_logs')) {
             Log::info('[ActionLog]' . $completedAction . ' / Diff: ' . $diff . 'ms');
         }
 
         $this->action->update([
-            'progress'  =>  $percent,
-            'runtime'   =>  $diff
+            'progress' => $percent,
+            'runtime' => $diff
         ]);
 
         ActionLogs::create([
-            'common_action_id'  =>  $this->action->id,
-            'log'   =>  $completedAction,
-            'runtime'   =>  $diff,
-            'iam_account_id'    => $this->getAccountId(),
-            'iam_user_id'       =>  $this->getUserId()
+            'common_action_id' => $this->action->id,
+            'log' => $completedAction,
+            'runtime' => $diff,
+            'iam_account_id' => $this->getAccountId(),
+            'iam_user_id' => $this->getUserId()
         ]);
     }
 
     public function setFinishedWithError($log = 'Action failed')
     {
+        if (!ActionsHelper::saveInDb()) return;
+
         $now = Carbon::now();
         $diff = $now->diffInMilliseconds($this->startTime);
 
-        if(config('leo.debug.action_logs')) {
+        if (config('leo.debug.action_logs')) {
             Log::info('[ActionLog][ERROR]' . $log . ' / Diff: ' . $diff . 'ms');
         }
 
         ActionLogs::create([
-            'common_action_id'  =>  $this->action->id,
-            'log'   =>  'Error: ' . $log,
-            'runtime'   =>  $diff,
-            'iam_account_id'    => $this->getAccountId(),
-            'iam_user_id'       =>  $this->getUserId()
+            'common_action_id' => $this->action->id,
+            'log' => 'Error: ' . $log,
+            'runtime' => $diff,
+            'iam_account_id' => $this->getAccountId(),
+            'iam_user_id' => $this->getUserId()
         ]);
 
         $this->action->update([
-            'progress'  =>  -1,
-            'runtime'   =>  $diff
+            'progress' => -1,
+            'runtime' => $diff
         ]);
     }
 
     public function setFinished($log = 'Action finished')
     {
+        if (!ActionsHelper::saveInDb()) return;
+
         $now = Carbon::now();
         $diff = $now->diffInMilliseconds($this->startTime);
 
-        if(config('leo.debug.action_logs')) {
+        if (config('leo.debug.action_logs')) {
             Log::info('[ActionLog]' . $log . ' / Diff: ' . $diff . 'ms');
         }
 
         ActionLogs::create([
-            'common_action_id'  =>  $this->action->id,
-            'log'   =>  'Action finished',
-            'runtime'   =>  $diff,
-            'iam_account_id'    => $this->getAccountId(),
-            'iam_user_id'       =>  $this->getUserId()
+            'common_action_id' => $this->action->id,
+            'log' => 'Action finished',
+            'runtime' => $diff,
+            'iam_account_id' => $this->getAccountId(),
+            'iam_user_id' => $this->getUserId()
         ]);
 
         $this->action->update([
-            'progress'  =>  100,
-            'runtime'   => $diff
+            'progress' => 100,
+            'runtime' => $diff
         ]);
     }
 

--- a/src/Helpers/ActionsHelper.php
+++ b/src/Helpers/ActionsHelper.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace NextDeveloper\Commons\Helpers;
+
+class ActionsHelper
+{
+    public static function saveInDb() : bool {
+        return config('commons.configuration.actions.save_in_db');
+    }
+}


### PR DESCRIPTION
This PR adds a new config option `commons.configuration.actions.save_in_db`, which can be configured by environment variable `ACTIONS_SAVE_IN_DB`. It is set to `true` by default. When it is set to `false`, no actions or action logs will be created in the database, thus dramatically speeding up development experience.