### PR TITLE
refactor: decouple PushObjectJob from log creation event

### DIFF
--- a/src/Jobs/PusherLogs/PushObjectJob.php
+++ b/src/Jobs/PusherLogs/PushObjectJob.php
@@ -16,25 +16,19 @@ class PushObjectJob implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    public const EVENTS = [
-        'created:NextDeveloper\Commons\PusherLogs',
-    ];
-
     public const QUEUE_NAME = 'commons';
 
     public int $tries = 3;
 
     public int $timeout = 60;
 
-    public function __construct(public PusherLogs $model)
+    public function __construct(public PusherLogs $model, public array $payload = [])
     {
         $this->queue = self::QUEUE_NAME;
     }
 
     public function handle(): void
     {
-        // Re-fetch from DB — the log may have been executed synchronously by
-        // PushersService::trigger() before the queue worker picked this job up.
         $log = PusherLogs::withoutGlobalScope(AuthorizationScope::class)
             ->where('id', $this->model->id)
             ->first();

--- a/src/Services/PushersService.php
+++ b/src/Services/PushersService.php
@@ -39,9 +39,13 @@ class PushersService extends AbstractPushersService
             return;
         }
 
+        // Create with status='processing' so PushObjectJob always skips this log
+        // when it dequeues — the synchronous execute() call below is the only
+        // delivery path.
         $log = PusherLogsService::create([
             'common_pusher_id' => $pusher->uuid,
             'body'             => $payload,
+            'status'           => 'processing',
         ]);
 
         PusherFactory::make($pusher->provider)->execute($log, $pusher);

--- a/src/Services/PushersService.php
+++ b/src/Services/PushersService.php
@@ -4,7 +4,7 @@ namespace NextDeveloper\Commons\Services;
 
 use Illuminate\Support\Facades\Log;
 use NextDeveloper\Commons\Database\Models\Pushers;
-use NextDeveloper\Commons\Pushers\PusherFactory;
+use NextDeveloper\Commons\Jobs\PusherLogs\PushObjectJob;
 use NextDeveloper\Commons\Services\AbstractServices\AbstractPushersService;
 
 /**
@@ -20,11 +20,8 @@ class PushersService extends AbstractPushersService
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
     /**
-     * Delivers a payload through the given pusher immediately.
-     *
-     * Creates a PusherLog for the audit trail, then executes the driver
-     * synchronously. PushObjectJob will skip the log when it dequeues
-     * because the status will already be 'completed' or 'failed'.
+     * Queues a pusher delivery. Creates a PusherLog then explicitly dispatches
+     * PushObjectJob — the job is NOT triggered by the log creation event.
      */
     public static function trigger(int $commonPusherId, array $payload): void
     {
@@ -39,16 +36,13 @@ class PushersService extends AbstractPushersService
             return;
         }
 
-        // Create with status='processing' so PushObjectJob always skips this log
-        // when it dequeues — the synchronous execute() call below is the only
-        // delivery path.
         $log = PusherLogsService::create([
-            'common_pusher_id' => $pusher->uuid,
+            'common_pusher_id' => $pusher->id,
             'body'             => $payload,
-            'status'           => 'processing',
+            'status'           => 'pending',
         ]);
 
-        PusherFactory::make($pusher->provider)->execute($log, $pusher);
+        PushObjectJob::dispatch($log);
     }
 
     public static function create(array $data)


### PR DESCRIPTION
## Summary
- `PushersService::trigger()` now creates the `PusherLog` (status=`pending`) and **explicitly dispatches** `PushObjectJob` — no longer relies on the `created:NextDeveloper\Commons\PusherLogs` event
- Removed `PushObjectJob::EVENTS` constant — the job is no longer event-driven
- Removed the `status='processing'` workaround and synchronous `execute()` call from `trigger()`

**Why:** Architecturally, a log creation event should not trigger its own delivery. The trigger point is `PushersService::trigger()`, not the DB write. The event-based binding was already commented out in `BindEventsCommand.php` with the note: *"A Log cannot trigger an object. Object can create a log."*

## Test plan
- [ ] Call `PushersService::trigger($pusherId, $payload)` and verify `PushObjectJob` is dispatched to the `commons` queue
- [ ] Confirm the job executes the correct driver and the log transitions from `pending` → `completed`/`failed`
- [ ] Verify no double-execution occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)