### PR TITLE
Dev

### DIFF
--- a/src/Actions/AbstractAction.php
+++ b/src/Actions/AbstractAction.php
@@ -345,7 +345,7 @@ class AbstractAction implements ShouldQueue
             $this->latestTime = now();
         } else {
             $now = Carbon::now();
-            $diff = $now->diffInMilliseconds($this->startTime);
+            $diff = (int) $now->diffInMilliseconds($this->startTime);
 
             $this->latestTime = now();
         }
@@ -387,7 +387,7 @@ class AbstractAction implements ShouldQueue
         if (!ActionsHelper::saveInDb()) return;
 
         $now = Carbon::now();
-        $diff = $now->diffInMilliseconds($this->startTime);
+        $diff = (int) $now->diffInMilliseconds($this->startTime);
 
         if (config('leo.debug.action_logs')) {
             Log::info('[ActionLog][ERROR][' . $this->actionName . ']' . $log . ' / Diff: ' . $diff . 'ms');
@@ -423,7 +423,7 @@ class AbstractAction implements ShouldQueue
         if (!ActionsHelper::saveInDb()) return;
 
         $now = Carbon::now();
-        $diff = $now->diffInMilliseconds($this->startTime);
+        $diff = (int) $now->diffInMilliseconds($this->startTime);
 
         if (config('leo.debug.action_logs')) {
             Log::info('[ActionLog][' . $this->actionName . ']' . $log . ' / Diff: ' . $diff . 'ms');

--- a/src/Actions/AbstractAction.php
+++ b/src/Actions/AbstractAction.php
@@ -345,7 +345,7 @@ class AbstractAction implements ShouldQueue
             $this->latestTime = now();
         } else {
             $now = Carbon::now();
-            $diff = (int) $now->diffInMilliseconds($this->startTime);
+            $diff = (int) abs($now->diffInMilliseconds($this->startTime));
 
             $this->latestTime = now();
         }
@@ -387,7 +387,7 @@ class AbstractAction implements ShouldQueue
         if (!ActionsHelper::saveInDb()) return;
 
         $now = Carbon::now();
-        $diff = (int) $now->diffInMilliseconds($this->startTime);
+        $diff = (int) abs($now->diffInMilliseconds($this->startTime));
 
         if (config('leo.debug.action_logs')) {
             Log::info('[ActionLog][ERROR][' . $this->actionName . ']' . $log . ' / Diff: ' . $diff . 'ms');
@@ -423,7 +423,7 @@ class AbstractAction implements ShouldQueue
         if (!ActionsHelper::saveInDb()) return;
 
         $now = Carbon::now();
-        $diff = (int) $now->diffInMilliseconds($this->startTime);
+        $diff = (int) abs($now->diffInMilliseconds($this->startTime));
 
         if (config('leo.debug.action_logs')) {
             Log::info('[ActionLog][' . $this->actionName . ']' . $log . ' / Diff: ' . $diff . 'ms');


### PR DESCRIPTION
[fix: cast diffInMilliseconds to int to prevent float value in integer…](https://github.com/nextdeveloper-nl/commons/commit/c9eaf57c3b09284a347fed11bef49d15313a2c9d)
[fix: use abs() on diffInMilliseconds to prevent negative runtime values](https://github.com/nextdeveloper-nl/commons/commit/661ba379c76d12e04c93f70f96a44cd354b973ad)