### PR TITLE
feat: add ObjectHelper with public/private object name conversion

### DIFF
--- a/src/Helpers/ObjectHelper.php
+++ b/src/Helpers/ObjectHelper.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace NextDeveloper\Commons\Helpers;
+
+use Illuminate\Support\Str;
+
+class ObjectHelper
+{
+    public static function getObject($objectType, $objectId)
+    {
+        $isUuid = Str::isUuid($objectId);
+
+        $explodedClass = explode('\\', $objectType);
+        if (count($explodedClass) == 3) {
+            $objectType = self::getPrivateObjectName($objectType);
+        }
+
+        if (!class_exists($objectType)) {
+            return null;
+        }
+
+        $object = new $objectType();
+
+        if ($isUuid) {
+            $object = $object->where('uuid', $objectId)->first();
+        } else {
+            $object = $object->where('id', $objectId)->first();
+        }
+
+        if ($object) {
+            return $object;
+        }
+
+        return null;
+    }
+
+    // Converts a full model class (e.g. NextDeveloper\IAAS\Database\Models\VirtualMachines)
+    // to its public short form (e.g. NextDeveloper\IAAS\VirtualMachines)
+    public static function getPublicObjectName($object): string
+    {
+        $class = is_string($object) ? $object : get_class($object);
+
+        return Str::replace('\Database\Models', '', $class);
+    }
+
+    // Converts a public short form (e.g. NextDeveloper\IAAS\VirtualMachines)
+    // to the full model class (e.g. \NextDeveloper\IAAS\Database\Models\VirtualMachines)
+    public static function getPrivateObjectName(string $objectType): string
+    {
+        $parts = explode('\\', $objectType);
+
+        if (count($parts) != 3) {
+            throw new \Exception('The object type is not valid. It should be in format Vendor\Package\ModelName');
+        }
+
+        return '\\' . $parts[0] . '\\' . $parts[1] . '\Database\\Models\\' . $parts[2];
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `NextDeveloper\Commons\Helpers\ObjectHelper` with three methods:
  - `getPublicObjectName()` — strips `\Database\Models` from a full model class name (e.g. `NextDeveloper\IAAS\Database\Models\VirtualMachines` → `NextDeveloper\IAAS\VirtualMachines`)
  - `getPrivateObjectName()` — reverses the above (short form → full model class)
  - `getObject()` — resolves and fetches a model by object type and ID/UUID

## Test plan
- [ ] Verify `getPublicObjectName()` strips `\Database\Models` correctly
- [ ] Verify `getPrivateObjectName()` reconstructs the full class path
- [ ] Verify `getObject()` returns `null` for missing classes/records

🤖 Generated with [Claude Code](https://claude.com/claude-code)