### PR TITLE
fix: avoid print_r(\$exception) in AbstractAction::failed() to preven…

### DIFF
--- a/src/Actions/AbstractAction.php
+++ b/src/Actions/AbstractAction.php
@@ -476,7 +476,11 @@ class AbstractAction implements ShouldQueue
 
     public function failed($exception)
     {
-        Log::error("[ActionLog][ERROR][' . $this->actionName . '] Action is failed with message: " . print_r($exception, true));
+        //  We avoid print_r($exception) here: PHP includes full function arguments in
+        //  exception traces by default, so dumping the whole object can re-serialize large
+        //  data (e.g. file listings, loaded models) once per stack frame and exhaust memory.
+        Log::error('[ActionLog][ERROR][' . $this->actionName . '] Action is failed with message: ' . $exception->getMessage());
+        Log::error($exception->getTraceAsString());
 
         $this->setFinishedWithError("In this job, we entered in an errored state.");
     }


### PR DESCRIPTION
…t OOM

print_r() on an exception dumps its full stack trace including every function argument at every frame (PHP includes args in traces by default). When a failure happens deep in a call chain carrying large data (e.g. IAAS repository sync processing big file listings/models), this re-serializes that data once per frame and can exhaust the PHP memory limit just while logging the error. Switch to getMessage() + getTraceAsString(), matching the existing pattern in setFinishedWithError().