### PR TITLE
fix: raise SCAN batch size in CacheHelper::deleteRedisKeys

### DIFF
--- a/src/Common/Cache/CacheHelper.php
+++ b/src/Common/Cache/CacheHelper.php
@@ -61,8 +61,11 @@ class CacheHelper
 
             //  This part is working correct, if there is a bug, look at elsewhere.
 
+            //  COUNT is raised from the phpredis default (10) to cut down the number of round trips
+            //  needed to walk the whole keyspace - on a large cache DB the default was slow enough
+            //  to blow past the queue worker timeout during cache invalidation.
             // Scanning through the keys that match the pattern
-            foreach ( $r->scan($it, '*' . self::getKey($obj, $id) . '*') as $k) {
+            foreach ( $r->scan($it, '*' . self::getKey($obj, $id) . '*', 1000) as $k) {
                 $r->del($k);
             }
         }


### PR DESCRIPTION
## Summary
- `deleteRedisKeys()` scanned the whole Redis cache DB using phpredis's default `COUNT=10` per `SCAN` call
- On a large cache DB this meant a huge number of network round trips just to invalidate a single object's keys, contributing to queue jobs blowing their timeout during cache invalidation
- Raises `COUNT` to 1000 to cut round trips drastically; behavior is unchanged

## Test plan
- [ ] Confirm cache invalidation still deletes the expected keys for an object
- [ ] Confirm no regression in Redis memory/CPU usage under normal load

🤖 Generated with [Claude Code](https://claude.com/claude-code)