### PR TITLE
feat: admin-only failed-jobs endpoint for AI diagnosis

### DIFF
--- a/config/commons.php
+++ b/config/commons.php
@@ -8,6 +8,14 @@ return [
         ]
     ],
 
+    'failed_jobs' => [
+        // Shared secret allowing token-based access to GET /commons/failed-jobs
+        // for callers (e.g. AI agents) that have no IAM user/OAuth token.
+        // Leave unset to disable the token path entirely (system-admin users
+        // can still use the endpoint via their normal session).
+        'api_token' => env('FAILED_JOBS_API_TOKEN'),
+    ],
+
     'configuration' => [
         'actions' => [
             'save_in_db' => env('ACTIONS_SAVE_IN_DB', true),

--- a/src/Database/Models/FailedJobs.php
+++ b/src/Database/Models/FailedJobs.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace NextDeveloper\Commons\Database\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use NextDeveloper\Commons\Database\Traits\UuidId;
+
+/**
+ * Maps to Laravel's core `failed_jobs` table — a global/system table, not
+ * tenant-scoped. No global scopes registered; access control is enforced
+ * entirely in FailedJobsController via an explicit system-admin check.
+ */
+class FailedJobs extends Model
+{
+    use UuidId;
+
+    public $timestamps = false;
+
+    protected $table = 'failed_jobs';
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'id'        => 'integer',
+        'failed_at' => 'datetime',
+    ];
+}

--- a/src/Http/Controllers/FailedJobs/FailedJobsController.php
+++ b/src/Http/Controllers/FailedJobs/FailedJobsController.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace NextDeveloper\Commons\Http\Controllers\FailedJobs;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use NextDeveloper\Commons\Http\Controllers\AbstractController;
+use NextDeveloper\Commons\Services\FailedJobsService;
+use NextDeveloper\IAM\Authorization\Roles\SystemAdminRole;
+use NextDeveloper\IAM\Helpers\UserHelper;
+
+class FailedJobsController extends AbstractController
+{
+    public function index(Request $request): JsonResponse
+    {
+        if (! $this->isAuthorized($request)) {
+            return response()->json([
+                'message' => 'Forbidden: only system-admin role or a valid failed-jobs API token can read and clear failed jobs.',
+            ], 403);
+        }
+
+        $validated = $request->validate([
+            'limit' => 'nullable|integer|min:1|max:100',
+        ]);
+
+        $limit = (int) ($validated['limit'] ?? FailedJobsService::DEFAULT_LIMIT);
+
+        $jobs = FailedJobsService::popBatch($limit);
+
+        return $this->withArray([
+            'count' => count($jobs),
+            'limit' => $limit,
+            'jobs'  => $jobs,
+        ]);
+    }
+
+    /**
+     * Allows either a logged-in system-admin user, or a caller presenting the
+     * static failed-jobs API token as a bearer token — AI agents diagnosing
+     * failures generally have no IAM user/OAuth token of their own, so this
+     * endpoint is also reachable via a shared secret sourced from the
+     * FAILED_JOBS_API_TOKEN env var (config('commons.failed_jobs.api_token')).
+     * This route is listed in `app.anonymous_uris`, so the global IAM
+     * Authenticate/Authorize middleware never runs for it — this check is the
+     * only gate, which is why an unset/empty configured token must never
+     * match (it would otherwise allow anyone through with no bearer token).
+     */
+    private function isAuthorized(Request $request): bool
+    {
+        if (UserHelper::hasRole(SystemAdminRole::NAME)) {
+            return true;
+        }
+
+        $configuredToken = config('commons.failed_jobs.api_token');
+        $providedToken = $request->bearerToken();
+
+        if (empty($configuredToken) || empty($providedToken)) {
+            return false;
+        }
+
+        return hash_equals($configuredToken, $providedToken);
+    }
+}

--- a/src/Http/api.routes.php
+++ b/src/Http/api.routes.php
@@ -869,6 +869,12 @@ Route::prefix('commons')->group(
                 Route::get('/', 'ExternalServices\ExternalServicesController@getAvailableServices');
             }
         );
+
+        Route::prefix('failed-jobs')->group(
+            function () {
+                Route::get('/', 'FailedJobs\FailedJobsController@index');
+            }
+        );
     }
 );
 

--- a/src/Services/FailedJobsService.php
+++ b/src/Services/FailedJobsService.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace NextDeveloper\Commons\Services;
+
+use Illuminate\Support\Facades\DB;
+use NextDeveloper\Commons\Database\Models\FailedJobs;
+
+class FailedJobsService
+{
+    public const DEFAULT_LIMIT     = 20;
+    public const MAX_LIMIT         = 100;
+    public const TRACE_FRAME_LIMIT = 15;
+    public const MAX_STRING_LENGTH = 500;
+    public const MAX_ARRAY_ITEMS   = 20;
+    public const MAX_DEPTH         = 3;
+
+    /**
+     * Reads up to $limit failed_jobs rows (oldest failed_at first), deletes
+     * exactly those rows, and returns them formatted for LLM consumption.
+     * Select + delete run in one transaction with a row lock so concurrent
+     * calls can't both "pop" the same rows.
+     */
+    public static function popBatch(int $limit): array
+    {
+        $limit = max(1, min(self::MAX_LIMIT, $limit ?: self::DEFAULT_LIMIT));
+
+        return DB::transaction(function () use ($limit) {
+            $rows = FailedJobs::orderBy('failed_at', 'asc')
+                ->orderBy('id', 'asc')
+                ->limit($limit)
+                ->lockForUpdate()
+                ->get();
+
+            if ($rows->isEmpty()) {
+                return [];
+            }
+
+            $formatted = $rows->map(fn (FailedJobs $row) => self::formatJob($row))->all();
+
+            FailedJobs::whereIn('id', $rows->pluck('id')->all())->delete();
+
+            return $formatted;
+        });
+    }
+
+    private static function formatJob(FailedJobs $row): array
+    {
+        $payload = json_decode($row->payload, true) ?? [];
+        $exceptionInfo = self::parseException((string) $row->exception);
+
+        return [
+            'id'         => $row->id,
+            'uuid'       => $row->uuid,
+            'job_class'  => self::resolveJobClass($payload),
+            'queue'      => $row->queue,
+            'connection' => $row->connection,
+            'failed_at'  => optional($row->failed_at)->toIso8601String(),
+            'exception'  => [
+                'class'   => $exceptionInfo['class'],
+                'message' => $exceptionInfo['message'] !== null
+                    ? self::truncateValue($exceptionInfo['message'])
+                    : null,
+                'file'    => $exceptionInfo['file'],
+                'line'    => $exceptionInfo['line'],
+            ],
+            'trace_excerpt'     => $exceptionInfo['trace_excerpt'],
+            'trace_frame_count' => $exceptionInfo['trace_frame_count'],
+            'payload'           => self::resolveJobArgs($payload),
+        ];
+    }
+
+    private static function resolveJobClass(array $payload): string
+    {
+        if (!empty($payload['data']['commandName']) && is_string($payload['data']['commandName'])) {
+            return $payload['data']['commandName'];
+        }
+        if (!empty($payload['displayName']) && is_string($payload['displayName'])) {
+            return $payload['displayName'];
+        }
+        if (!empty($payload['job']) && is_string($payload['job'])) {
+            return explode('@', $payload['job'])[0];
+        }
+        return 'unknown';
+    }
+
+    private static function resolveJobArgs(array $payload)
+    {
+        // Normal ShouldQueue jobs/commands: payload.data.command is a serialize()'d PHP object.
+        if (isset($payload['data']['command']) && is_string($payload['data']['command'])) {
+            return self::extractCommandArgs($payload['data']['command']);
+        }
+
+        // Rare string-dispatch path (Queue::push('Class@method', $data)): payload.data IS the args array.
+        if (isset($payload['data']) && is_array($payload['data'])) {
+            return self::truncateValue($payload['data']);
+        }
+
+        return null;
+    }
+
+    private static function extractCommandArgs(string $serialized)
+    {
+        if (!str_starts_with($serialized, 'O:')) {
+            // Most likely ShouldBeEncrypted or an unrecognized format — can't generically decode.
+            return '(command payload is encrypted or in an unrecognized format; cannot decode)';
+        }
+
+        try {
+            // allowed_classes: false — returns __PHP_Incomplete_Class stand-ins with all property
+            // values intact, but never autoloads the real class or invokes __wakeup()/__unserialize().
+            // Defense in depth against object-injection via stored payload strings.
+            $object = @unserialize($serialized, ['allowed_classes' => false]);
+        } catch (\Throwable $e) {
+            return '(failed to unserialize command payload: ' . $e->getMessage() . ')';
+        }
+
+        if (!is_object($object)) {
+            return '(failed to unserialize command payload)';
+        }
+
+        $props = [];
+        foreach ((array) $object as $key => $value) {
+            if ($key === '__PHP_Incomplete_Class_Name') {
+                $props['__declared_class__'] = $value;
+                continue;
+            }
+            // Strip PHP's null-byte visibility prefix on protected/private props from an array cast.
+            $cleanKey = preg_replace('/^\x00.*?\x00/', '', $key);
+            $props[$cleanKey] = self::truncateValue($value);
+        }
+
+        return $props;
+    }
+
+    private static function parseException(string $exceptionText): array
+    {
+        // `exception` column is Throwable::__toString() format (written by
+        // Illuminate\Queue\Failed\DatabaseUuidFailedJobProvider::log()):
+        //   "{Class}: {message} in {file}:{line}\nStack trace:\n#0 ...\n#N {main}"
+        $lines = explode("\n", $exceptionText);
+        $header = $lines[0] ?? '';
+
+        $class = null; $message = null; $file = null; $line = null;
+
+        if (($colonPos = strpos($header, ': ')) !== false) {
+            $class = substr($header, 0, $colonPos);
+            $rest = substr($header, $colonPos + 2);
+
+            if (($inPos = strrpos($rest, ' in ')) !== false) {
+                $message = substr($rest, 0, $inPos);
+                $fileLine = substr($rest, $inPos + 4);
+
+                if (($lastColon = strrpos($fileLine, ':')) !== false) {
+                    $file = substr($fileLine, 0, $lastColon);
+                    $line = (int) substr($fileLine, $lastColon + 1);
+                }
+            } else {
+                $message = $rest;
+            }
+        } else {
+            $message = $header;
+        }
+
+        $traceStart = null;
+        foreach ($lines as $i => $l) {
+            if (trim($l) === 'Stack trace:') { $traceStart = $i + 1; break; }
+        }
+
+        $traceLines = [];
+        if ($traceStart !== null) {
+            $traceLines = array_values(array_filter(
+                array_slice($lines, $traceStart),
+                fn ($l) => trim($l) !== ''
+            ));
+        }
+
+        $frameCount = count($traceLines);
+        $excerpt = array_slice($traceLines, 0, self::TRACE_FRAME_LIMIT);
+
+        if ($frameCount > self::TRACE_FRAME_LIMIT) {
+            $excerpt[] = sprintf('... (%d more frames omitted)', $frameCount - self::TRACE_FRAME_LIMIT);
+        }
+
+        return [
+            'class' => $class, 'message' => $message, 'file' => $file, 'line' => $line,
+            'trace_excerpt' => $excerpt, 'trace_frame_count' => $frameCount,
+        ];
+    }
+
+    private static function truncateValue($value, int $depth = 0)
+    {
+        if ($depth > self::MAX_DEPTH) {
+            return '(truncated: max depth reached)';
+        }
+
+        if (is_string($value)) {
+            return strlen($value) > self::MAX_STRING_LENGTH
+                ? substr($value, 0, self::MAX_STRING_LENGTH) . sprintf('... (truncated, %d bytes total)', strlen($value))
+                : $value;
+        }
+
+        if (is_array($value)) {
+            $out = []; $i = 0;
+            foreach ($value as $k => $v) {
+                if ($i++ >= self::MAX_ARRAY_ITEMS) { $out['__truncated__'] = 'more items omitted'; break; }
+                $out[$k] = self::truncateValue($v, $depth + 1);
+            }
+            return $out;
+        }
+
+        if (is_object($value)) {
+            $repr = ['__class__' => get_class($value)];
+            foreach (['id', 'uuid'] as $idField) {
+                if (isset($value->{$idField})) { $repr[$idField] = $value->{$idField}; }
+            }
+            return $repr;
+        }
+
+        return $value;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `GET /commons/failed-jobs?limit=` — reads a bounded, oldest-first batch of `failed_jobs` rows, condenses each into an LLM-readable summary (job class, exception class/message/file/line, truncated stack trace, decoded job args), and deletes exactly the rows returned in one transaction.
- Access: `system-admin` role, or a bearer token matching `FAILED_JOBS_API_TOKEN` (for AI agents with no IAM user). Route is listed in the host app's `anonymous_uris` so the global IAM middleware doesn't block token-only callers; the controller is the sole gate.
- New `FailedJobsService::popBatch()` holds the select-lock-format-delete logic; `FailedJobs` model is deliberately minimal (no tenant scopes/traits — `failed_jobs` is a global system table).

## Test plan
- [x] `php -l` on all new/changed files
- [x] Seeded rows via tinker, called `FailedJobsService::popBatch()` directly — confirmed correct job-class/exception parsing for both object-dispatch and string-dispatch payloads, oldest-first ordering, exact deletion of returned rows, graceful degradation on malformed rows, empty-table case
- [x] Verified `isAuthorized()` via reflection: no token → deny, wrong token → deny, correct token → allow, token supplied but config unset → deny
- [ ] Full HTTP round trip (blocked locally by a pre-existing, unrelated `php artisan serve` bootstrap failure in `IAASServiceProvider`)