### PR TITLE
fix: guard hasRole() check for anonymous failed-jobs requests

### DIFF
--- a/src/Http/Controllers/FailedJobs/FailedJobsController.php
+++ b/src/Http/Controllers/FailedJobs/FailedJobsController.php
@@ -47,7 +47,11 @@ class FailedJobsController extends AbstractController
      */
     private function isAuthorized(Request $request): bool
     {
-        if (UserHelper::hasRole(SystemAdminRole::NAME)) {
+        // UserHelper::hasRole() assumes an authenticated user; calling it for a
+        // fully anonymous request (no bearer token at all, e.g. an unauthenticated
+        // AI-agent call) throws inside UserHelper::getRoles(), so only try the
+        // role check once we know a user actually resolved.
+        if (UserHelper::me() && UserHelper::hasRole(SystemAdminRole::NAME)) {
             return true;
         }
 


### PR DESCRIPTION
## Summary
- Fixes a 500 on `GET /commons/failed-jobs` for every fully-anonymous request (no bearer token at all), discovered while testing the token-auth path added in #239 against production.
- `UserHelper::hasRole()` → `UserHelper::getRoles()` returns `null` for a caller with no resolvable user, and `UserHelper::has()` does an unguarded `foreach` over it, throwing an `ErrorException`. Since this route is in the host app's `anonymous_uris`, the global auth middleware no longer blocks anonymous callers before reaching the controller — so this path is now reachable and was crashing before the token check ever ran.
- Fix: only call `hasRole()` once `UserHelper::me()` confirms an actual user resolved.

## Test plan
- [x] Reproduced locally via `php artisan serve` + curl with no `Authorization` header → 500 before the fix, 403 after
- [x] Wrong token → 403, correct token → 200 with the full pop/format/delete cycle, both re-verified after the fix