### PR TITLE
fix: avoid property access on incomplete objects in truncateValue()

### DIFF
--- a/src/Services/FailedJobsService.php
+++ b/src/Services/FailedJobsService.php
@@ -209,10 +209,29 @@ class FailedJobsService
         }
 
         if (is_object($value)) {
-            $repr = ['__class__' => get_class($value)];
-            foreach (['id', 'uuid'] as $idField) {
-                if (isset($value->{$idField})) { $repr[$idField] = $value->{$idField}; }
+            // Never access properties via -> here: unserialize(..., ['allowed_classes' => false])
+            // turns every nested object (e.g. Illuminate\Contracts\Database\ModelIdentifier, used
+            // whenever a job property holds an Eloquent model) into a __PHP_Incomplete_Class stand-in,
+            // and PHP raises "tried to access a property on an incomplete object" on any -> access,
+            // which this app escalates to a fatal ErrorException. An (array) cast reads the same data
+            // without touching the object's magic accessors.
+            $className = get_class($value);
+            $props = (array) $value;
+            $repr = ['__class__' => $className];
+
+            foreach ($props as $key => $v) {
+                $cleanKey = preg_replace('/^\x00.*?\x00/', '', (string) $key);
+
+                if ($cleanKey === '__PHP_Incomplete_Class_Name') {
+                    $repr['__class__'] = $v;
+                    continue;
+                }
+
+                if (in_array($cleanKey, ['id', 'uuid'], true) && (is_scalar($v) || is_null($v))) {
+                    $repr[$cleanKey] = $v;
+                }
             }
+
             return $repr;
         }
 


### PR DESCRIPTION
## Summary
- Fixes the production 500 reported on `GET /commons/failed-jobs` with a valid token: `truncateValue()`'s object branch did `isset($value->{$field})`, which throws "tried to access a property on an incomplete object" whenever `$value` is a `__PHP_Incomplete_Class` stand-in — which is exactly what `unserialize(..., ['allowed_classes' => false])` produces for any nested object, including `Illuminate\Contracts\Database\ModelIdentifier` (substituted by Laravel whenever a queued job property holds an Eloquent model — a common, realistic case, which is exactly what a real production failed job hit).
- Fix: use an `(array)` cast to read `id`/`uuid` instead of `->` property access, matching the approach `extractCommandArgs()` already uses for the top-level command object.

## Test plan
- [x] Reproduced the exact production error locally via tinker (constructed a job with a nested object property, unserialized with `allowed_classes => false`, confirmed `isset($nested->id)` throws the identical warning)
- [x] Confirmed the fix resolves it: `extractCommandArgs()` on the same reproduction now returns `{"__class__":"...","id":42}` instead of throwing
- [x] Re-ran the full local regression (seed → popBatch → correct parsing/deletion) — unaffected